### PR TITLE
Add placeholder upload

### DIFF
--- a/app/Http/Controllers/PagesController.php
+++ b/app/Http/Controllers/PagesController.php
@@ -54,6 +54,13 @@ class PagesController extends Controller
 			'description' => $description,
 			'body' => $body
 		]);
+
+		if (Request::hasFile('thumbnail')) {
+			$path = str_replace('/app', '', app_path());
+			$thumbnail = Request::file('thumbnail');
+			$thumbnail->move($path . '/public/images/projects',  'product' . $newEntry->id . '.jpg');
+		}
+
 		return redirect('/project/' . $newEntry->id);
 	}
  

--- a/resources/views/pages/create.blade.php
+++ b/resources/views/pages/create.blade.php
@@ -14,6 +14,10 @@
 
         <h5>Create Project</h5>
         <div class="form-group">
+            <label for="thumbnail">Thumbnail</label>
+            <input class="form-control" type="file" id="thumbnail" name="thumbnail">
+        </div>
+        <div class="form-group">
             <label for="title">Title</label>
             <input class="form-control" type="text" id="title" name="title" placeholder="Your project's title">
         </div>


### PR DESCRIPTION
Resolves #48. Could use some validation (i.e. is an image), along with disallowing the form at `/create` to be submitted without being fully filled out.
- Enable upload on create project page
  - uploads to `/public/images/projects`
