### PR TITLE
Project Routes and Validation

### DIFF
--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\CreateProjectRequest;
 use App\Project;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Request;
 
 class ProjectController extends Controller
 {
@@ -35,16 +35,15 @@ class ProjectController extends Controller
     /**
      * Creates a new project using the input from the form
      *
+     * @param CreateProjectRequest $request The validated request
      * @return mixed
      */
-    public function create()
+    public function create(CreateProjectRequest $request)
     {
-        if (Auth::guest()) {
-            return redirect('/login');
-        }
-        $title = Request::input('title');
-        $description = Request::input('description');
-        $body = Request::input('project-body');
+        $title = $request->input('title');
+        $description = $request->input('description');
+        $body = $request->input('project-body');
+
         $newEntry = Project::create([
             'author' => Auth::user()->username,
             'title'  => $title,
@@ -52,11 +51,9 @@ class ProjectController extends Controller
             'body' => $body
         ]);
 
-        if (Request::hasFile('thumbnail')) {
-            $path = str_replace('/app', '', app_path());
-            $thumbnail = Request::file('thumbnail');
-            $thumbnail->move($path . '/public/images/projects',  'product' . $newEntry->id . '.jpg');
-        }
+        $path = str_replace('/app', '', app_path());
+        $thumbnail = $request->file('thumbnail');
+        $thumbnail->move($path . '/public/images/projects',  'product' . $newEntry->id . '.jpg');
 
         return redirect('/project/' . $newEntry->id);
     }

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -54,11 +54,10 @@ class ProjectController extends Controller
             'body' => $body
         ]);
 
-        $path = str_replace('/app', '', app_path());
         $thumbnail = $request->file('thumbnail');
-        $thumbnail->move($path . '/public/images/projects',  'product' . $newEntry->id . '.jpg');
+        $thumbnail->move(base_path() . '/public/images/projects',  'product' . $newEntry->id . '.jpg');
 
-        return redirect('/project/' . $newEntry->id);
+        return redirect($newEntry->getSlug());
     }
 
     /**

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\CreateProjectRequest;
+use App\Http\Requests\DeleteProjectRequest;
 use App\Project;
 use Illuminate\Support\Facades\Auth;
 
@@ -62,30 +63,15 @@ class ProjectController extends Controller
      * Deletes the project give by the id, only if the user
      * is authenticated and is the author.
      *
-     * @param $id the project id for lookup
+     * @param DeleteProjectRequest $request
      * @return mixed
      */
-    public function delete($id)
+    public function delete(DeleteProjectRequest $request)
     {
-        if (Auth::guest()) {
-            return redirect('/login');
-        }
-
-        $project = Project::find($id);
-        if ($project == null) {
-            // TODO: Redirect to an error page
-            return redirect('/projectfinder');
-        }
-
-        if ($project->author == Auth::user()->username) {
-            $project->delete();
-            $imagePath = base_path() . '/public/images/projects/product' . $id . '.jpg';
-            if (file_exists($imagePath)) {
-                unlink($imagePath);
-            }
-        }
+        $project = $request->project;
+        $project->delete();
 
         // TODO: Notice of success?
-        return redirect('/projectfinder');
+        return redirect()->action('PagesController@projectfinder');
     }
 }

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -6,18 +6,20 @@ use App\Http\Requests\CreateProjectRequest;
 use App\Http\Requests\DeleteProjectRequest;
 use App\Project;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Session;
 
 class ProjectController extends Controller
 {
     /**
      * Renders the Project View for the given id
      *
-     * @param $id project id for lookup
+     * @param Project $project
      * @return The project page view
+     * @internal param Project $id id for lookup
      */
-    public function view($id)
+    public function view(Project $project)
     {
-        return view('pages.project', ['project' => Project::find($id)]);
+        return view('pages.project', ['project' => $project]);
     }
 
     /**
@@ -25,12 +27,12 @@ class ProjectController extends Controller
      *
      * @return mixed
      */
-    public function createProjectPage()
+    public function createForm()
     {
         if (Auth::guest()) {
             return redirect('/login');
         }
-        return view('pages.create');
+        return view('pages.project-create');
     }
 
     /**
@@ -69,9 +71,10 @@ class ProjectController extends Controller
     public function delete(DeleteProjectRequest $request)
     {
         $project = $request->project;
+        $title = $project->title;
         $project->delete();
 
-        // TODO: Notice of success?
+        Session::flash('delete-success', 'Successfully deleted the project "' . $title .'"');
         return redirect()->action('PagesController@projectfinder');
     }
 }

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -43,15 +43,11 @@ class ProjectController extends Controller
      */
     public function create(CreateProjectRequest $request)
     {
-        $title = $request->input('title');
-        $description = $request->input('description');
-        $body = $request->input('project-body');
-
         $newEntry = Project::create([
             'author' => Auth::user()->username,
-            'title'  => $title,
-            'description' => $description,
-            'body' => $body
+            'title'  => $request->getTitle(),
+            'description' => $request->getDescription(),
+            'body' => $request->getBody()
         ]);
 
         $thumbnail = $request->file('thumbnail');

--- a/app/Http/Requests/CreateProjectRequest.php
+++ b/app/Http/Requests/CreateProjectRequest.php
@@ -24,7 +24,7 @@ class CreateProjectRequest extends Request
     public function rules()
     {
         return [
-            'title' => 'required|unique:projects|' . $this->minMaxFormatter('title'),
+            'title' => 'required|unique:projects|regex:/([A-Za-z0-9_ .]+)/|' . $this->minMaxFormatter('title'),
             'description' => 'required|' . $this->minMaxFormatter('description'),
             'project-body' => 'required|' . $this->minMaxFormatter('project-body'),
             'thumbnail' => 'required|image|max:2048'    // max image size 2mb

--- a/app/Http/Requests/CreateProjectRequest.php
+++ b/app/Http/Requests/CreateProjectRequest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Project;
+
+class CreateProjectRequest extends Request
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return $this->user() != null;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'title' => 'required|unique:projects|' . $this->minMaxFormatter('title'),
+            'description' => 'required|' . $this->minMaxFormatter('description'),
+            'project-body' => 'required|' . $this->minMaxFormatter('project-body'),
+            'thumbnail' => 'required|image|max:2048'    // max image size 2mb
+        ];
+    }
+
+    /**
+     * Helper function to format the min/max rules
+     *
+     * @param $field
+     * @return string formatted (i.e. "min:2|max:20")
+     */
+    private function minMaxFormatter($field)
+    {
+        return 'min:' . Project::attributeLengths()[$field]['min'] . '|max:' . Project::attributeLengths()[$field]['max'];
+    }
+
+    /**
+     * The messages that this returns on errors.
+     *
+     * @return array
+     */
+    public function messages()
+    {
+        return [
+            'title' => [
+                'required' => 'A title is required.',
+                'unique' => 'The title must be unique.',
+                'min' => 'The title must be longer.',
+                'max' => 'The title must be shorter than 50 characters.',
+            ],
+            'description' => [
+                'required' => 'A description is required.',
+                'min' => 'Description must be at least 10 characters.',
+                'max' => 'Description must be shorter than 100 characters.',
+            ],
+            'project-body' => [
+                'required' => 'A full explanation of the project is required.' ,
+                'min' => 'Project explanation must be at least 100 characters.',
+                'max' => 'Project explanation must be shorter than 65535 characters.',
+            ],
+            'thumbnail' => [
+                'required' => 'An image for the project is required.',
+                'max' => 'The file is larger than 2mb.',
+                'image' => 'File is not an image.',
+            ]
+        ];
+    }
+}

--- a/app/Http/Requests/CreateProjectRequest.php
+++ b/app/Http/Requests/CreateProjectRequest.php
@@ -17,6 +17,36 @@ class CreateProjectRequest extends Request
     }
 
     /**
+     * Helper to get the title for this request.
+     *
+     * @return array|string
+     */
+    public function getTitle()
+    {
+        return $this->input('title');
+    }
+
+    /**
+     * Helper to get the description for this request.
+     *
+     * @return array|string
+     */
+    public function getDescription()
+    {
+        return $this->input('description');
+    }
+
+    /**
+     * Helper to get the body for this request.
+     *
+     * @return array|string
+     */
+    public function getBody()
+    {
+        return $this->input('project-body');
+    }
+
+    /**
      * Get the validation rules that apply to the request.
      *
      * @return array
@@ -24,9 +54,9 @@ class CreateProjectRequest extends Request
     public function rules()
     {
         return [
-            'title' => 'required|unique:projects|regex:/([A-Za-z0-9_ .]+)/|' . $this->minMaxFormatter('title'),
-            'description' => 'required|' . $this->minMaxFormatter('description'),
-            'project-body' => 'required|' . $this->minMaxFormatter('project-body'),
+            'title' => 'required|unique:projects|regex:/(?=.*[a-zA-Z0-9])([A-Za-z0-9_ .]+)/|' . $this->betweenFormatter('title'),
+            'description' => 'required|regex:/(?=.*[a-zA-Z0-9])([A-Za-z0-9_ .]+)/|' . $this->betweenFormatter('description'),
+            'project-body' => 'required|regex:/(?=.*[a-zA-Z0-9])([A-Za-z0-9_ .]+)/|' . $this->betweenFormatter('project-body'),
             'thumbnail' => 'required|image|max:2048'    // max image size 2mb
         ];
     }
@@ -37,9 +67,9 @@ class CreateProjectRequest extends Request
      * @param $field
      * @return string formatted (i.e. "min:2|max:20")
      */
-    private function minMaxFormatter($field)
+    private function betweenFormatter($field)
     {
-        return 'min:' . Project::attributeLengths()[$field]['min'] . '|max:' . Project::attributeLengths()[$field]['max'];
+        return 'between:' . Project::attributeLengths()[$field]['min'] . ',' . Project::attributeLengths()[$field]['max'];
     }
 
     /**
@@ -50,27 +80,22 @@ class CreateProjectRequest extends Request
     public function messages()
     {
         return [
-            'title' => [
-                'required' => 'A title is required.',
-                'unique' => 'The title must be unique.',
-                'min' => 'The title must be longer.',
-                'max' => 'The title must be shorter than 50 characters.',
-            ],
-            'description' => [
-                'required' => 'A description is required.',
-                'min' => 'Description must be at least 10 characters.',
-                'max' => 'Description must be shorter than 100 characters.',
-            ],
-            'project-body' => [
-                'required' => 'A full explanation of the project is required.' ,
-                'min' => 'Project explanation must be at least 100 characters.',
-                'max' => 'Project explanation must be shorter than 65535 characters.',
-            ],
-            'thumbnail' => [
-                'required' => 'An image for the project is required.',
-                'max' => 'The file is larger than 2mb.',
-                'image' => 'File is not an image.',
-            ]
+            'title.required' => 'A title is required.',
+            'title.unique' => 'The title must be unique.',
+            'title.regex' => 'The :attribute must contain at least one letter/number.',
+            'title.between' => 'The :attribute must be from :min to :max characters.',
+
+            'description.required' => 'A description is required.',
+            'description.between' => 'Description must be from :min to :max characters.',
+            'description.regex' => 'The :attribute must contain at least one letter/number.',
+
+            'project-body.required' => 'A full explanation of the project is required.' ,
+            'project-body.between' => 'Project explanation must be between :min and :max characters.',
+            'project-body.regex' => 'The :attribute must contain at least one letter/number.',
+
+            'thumbnail.required' => 'An image for the project is required.',
+            'thumbnail.max' => 'The file is larger than .',
+            'thumbnail.image' => 'File is not an image.',
         ];
     }
 }

--- a/app/Http/Requests/DeleteProjectRequest.php
+++ b/app/Http/Requests/DeleteProjectRequest.php
@@ -2,10 +2,6 @@
 
 namespace App\Http\Requests;
 
-
-use App\Project;
-use Illuminate\Support\Facades\Auth;
-
 class DeleteProjectRequest extends Request
 {
     /**
@@ -15,8 +11,8 @@ class DeleteProjectRequest extends Request
      */
     public function authorize()
     {
-        $user = $this->user();
-        return $this->user() != null && $this->project->author == $user->username;
+        return $this->project->isUserAuthor($this->user());
+
     }
 
     /**

--- a/app/Http/Requests/DeleteProjectRequest.php
+++ b/app/Http/Requests/DeleteProjectRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+
+use App\Project;
+use Illuminate\Support\Facades\Auth;
+
+class DeleteProjectRequest extends Request
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        $user = $this->user();
+        return $this->user() != null && $this->project->author == $user->username;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [];
+    }
+}

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -39,8 +39,8 @@ Route::get('projectfinder', 'PagesController@projectfinder');
 /*-----------------------*
  *  Project Controller   *
  *-----------------------*/
-Route::get('/project/{id}', 'ProjectController@view');
-Route::get('/create', 'ProjectController@createProjectPage');
-Route::post('/create', 'ProjectController@create');
-Route::get('/delete-project/{project}', 'ProjectController@delete');
+Route::get('/project/{project}', 'ProjectController@view');
+Route::get('/project-create', 'ProjectController@createForm');        // can't do `/project/create` as it tries to find the project `create`
+Route::post('/project-create', 'ProjectController@create');
+Route::get('/project/{project}/delete', 'ProjectController@delete');
 

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -42,5 +42,5 @@ Route::get('projectfinder', 'PagesController@projectfinder');
 Route::get('/project/{id}', 'ProjectController@view');
 Route::get('/create', 'ProjectController@createProjectPage');
 Route::post('/create', 'ProjectController@create');
-Route::get('/delete-project/{id}', 'ProjectController@delete');
+Route::get('/delete-project/{project}', 'ProjectController@delete');
 

--- a/app/Project.php
+++ b/app/Project.php
@@ -11,6 +11,16 @@ class Project extends Model
     ];
 
     /**
+     * Gets this projects url
+     *
+     * @return string
+     */
+    public function getSlug()
+    {
+        return '/project/' . str_replace(' ', '-', $this->title);
+    }
+
+    /**
      * Get the path to the image for this project.
      *
      * @return string the path

--- a/app/Project.php
+++ b/app/Project.php
@@ -9,4 +9,20 @@ class Project extends Model
     protected $fillable = [
         'title', 'author', 'description', 'body', 'created_at', 'updated_at'
     ];
+
+    public static function attributeLengths()
+    {
+        return [
+            'title' => Project::minMaxHelper(2, 50),
+            'description' => Project::minMaxHelper(10, 100),
+            'project-body' => Project::minMaxHelper(100, 65535)
+        ];
+    }
+
+    private static function minMaxHelper($min, $max) {
+        return [
+            'min' => $min,
+            'max' => $max
+        ];
+    }
 }

--- a/app/Project.php
+++ b/app/Project.php
@@ -10,22 +10,6 @@ class Project extends Model
         'title', 'author', 'description', 'body', 'created_at', 'updated_at'
     ];
 
-    public static function attributeLengths()
-    {
-        return [
-            'title' => Project::minMaxHelper(2, 50),
-            'description' => Project::minMaxHelper(10, 100),
-            'project-body' => Project::minMaxHelper(100, 65535)
-        ];
-    }
-
-    private static function minMaxHelper($min, $max) {
-        return [
-            'min' => $min,
-            'max' => $max
-        ];
-    }
-
     /**
      * Get the path to the image for this project.
      *
@@ -52,5 +36,40 @@ class Project extends Model
         }
 
         return $res;
+    }
+
+    /**
+     * Checks if the provided is non-null and authored this project
+     *
+     * @param $user The user to check (nullable)
+     * @return bool if the provided user authored this project
+     */
+    public function isUserAuthor($user)
+    {
+        if ($user == null) {
+            return false;
+        }
+        return $user->username == $this->author;
+    }
+
+    /**
+     * Returns the array of lengths required for the attributes.
+     *
+     * @return array
+     */
+    public static function attributeLengths()
+    {
+        return [
+            'title' => Project::minMaxHelper(2, 50),
+            'description' => Project::minMaxHelper(10, 100),
+            'project-body' => Project::minMaxHelper(100, 65535)
+        ];
+    }
+
+    private static function minMaxHelper($min, $max) {
+        return [
+            'min' => $min,
+            'max' => $max
+        ];
     }
 }

--- a/app/Project.php
+++ b/app/Project.php
@@ -25,4 +25,32 @@ class Project extends Model
             'max' => $max
         ];
     }
+
+    /**
+     * Get the path to the image for this project.
+     *
+     * @return string the path
+     */
+    public function getImagePath()
+    {
+        return base_path() . '/public/images/projects/product' . $this->id . '.jpg';
+    }
+
+    /**
+     * Override the default model delete method to include deleting the image.
+     *
+     * @return bool|null
+     * @throws \Exception
+     */
+    public function delete()
+    {
+        $res = parent::delete();
+
+        $imagePath = $this->getImagePath();
+        if (file_exists($imagePath)) {  // Shouldn't be null, let's check for sanity
+            unlink($imagePath);
+        }
+
+        return $res;
+    }
 }

--- a/app/Project.php
+++ b/app/Project.php
@@ -27,7 +27,7 @@ class Project extends Model
      */
     public function getImagePath()
     {
-        return base_path() . '/public/images/projects/product' . $this->id . '.jpg';
+        return '/images/projects/product' . $this->id . '.jpg';
     }
 
     /**

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Project;
 use Illuminate\Routing\Router;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
 
@@ -26,7 +27,10 @@ class RouteServiceProvider extends ServiceProvider
     {
         parent::boot($router);
 
-        $router->model('project', 'App\Project');
+        $router->bind('project', function($title) {
+            $title = str_replace('-', ' ', $title);
+            return Project::where('title', $title)->first();
+        });
     }
 
     /**

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -24,9 +24,9 @@ class RouteServiceProvider extends ServiceProvider
      */
     public function boot(Router $router)
     {
-        //
-
         parent::boot($router);
+
+        $router->model('project', 'App\Project');
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "type": "project",
     "require": {
         "php": ">=5.5.9",
-        "laravel/framework": "5.2.*"
+        "laravel/framework": "5.2.*",
+        "laravelcollective/html": "5.2.*"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "c284a9c122da36c99a8b6597bdce7aa6",
-    "content-hash": "8b1485987e7c5949da82435d403e52e8",
+    "hash": "0a0a74589e1132c44af272069b8bf05e",
+    "content-hash": "98074360a603e8487076fd5e836179ae",
     "packages": [
         {
             "name": "classpreloader/classpreloader",
@@ -308,16 +308,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v5.2.26",
+            "version": "v5.2.29",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "b73ac62506c5c2bd49d87fcb1089f7759431e173"
+                "reference": "e3d644eb131f18c5f3d28ff7bc678bc797091f20"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/b73ac62506c5c2bd49d87fcb1089f7759431e173",
-                "reference": "b73ac62506c5c2bd49d87fcb1089f7759431e173",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/e3d644eb131f18c5f3d28ff7bc678bc797091f20",
+                "reference": "e3d644eb131f18c5f3d28ff7bc678bc797091f20",
                 "shasum": ""
             },
             "require": {
@@ -432,7 +432,61 @@
                 "framework",
                 "laravel"
             ],
-            "time": "2016-03-25 17:12:52"
+            "time": "2016-04-03 01:43:55"
+        },
+        {
+            "name": "laravelcollective/html",
+            "version": "v5.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/LaravelCollective/html.git",
+                "reference": "3a312d39ffe37da0f57b602618b61fd07c1fcec5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/LaravelCollective/html/zipball/3a312d39ffe37da0f57b602618b61fd07c1fcec5",
+                "reference": "3a312d39ffe37da0f57b602618b61fd07c1fcec5",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/http": "5.2.*",
+                "illuminate/routing": "5.2.*",
+                "illuminate/session": "5.2.*",
+                "illuminate/support": "5.2.*",
+                "illuminate/view": "5.2.*",
+                "php": ">=5.5.9"
+            },
+            "require-dev": {
+                "illuminate/database": "5.2.*",
+                "mockery/mockery": "~0.9",
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Collective\\Html\\": "src/"
+                },
+                "files": [
+                    "src/helpers.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylorotwell@gmail.com"
+                },
+                {
+                    "name": "Adam Engebretson",
+                    "email": "adam@laravelcollective.com"
+                }
+            ],
+            "description": "HTML and Form Builders for the Laravel Framework",
+            "homepage": "http://laravelcollective.com",
+            "time": "2016-01-27 22:29:54"
         },
         {
             "name": "league/flysystem",
@@ -519,16 +573,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "1.18.1",
+            "version": "1.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "a5f2734e8c16f3aa21b3da09715d10e15b4d2d45"
+                "reference": "5f56ed5212dc509c8dc8caeba2715732abb32dbf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/a5f2734e8c16f3aa21b3da09715d10e15b4d2d45",
-                "reference": "a5f2734e8c16f3aa21b3da09715d10e15b4d2d45",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/5f56ed5212dc509c8dc8caeba2715732abb32dbf",
+                "reference": "5f56ed5212dc509c8dc8caeba2715732abb32dbf",
                 "shasum": ""
             },
             "require": {
@@ -543,13 +597,13 @@
                 "doctrine/couchdb": "~1.0@dev",
                 "graylog2/gelf-php": "~1.0",
                 "jakub-onderka/php-parallel-lint": "0.9",
+                "php-amqplib/php-amqplib": "~2.4",
                 "php-console/php-console": "^3.1.3",
                 "phpunit/phpunit": "~4.5",
                 "phpunit/phpunit-mock-objects": "2.3.0",
                 "raven/raven": "^0.13",
                 "ruflin/elastica": ">=0.90 <3.0",
-                "swiftmailer/swiftmailer": "~5.3",
-                "videlalvaro/php-amqplib": "~2.4"
+                "swiftmailer/swiftmailer": "~5.3"
             },
             "suggest": {
                 "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
@@ -558,11 +612,11 @@
                 "ext-mongo": "Allow sending log messages to a MongoDB server",
                 "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
                 "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
                 "php-console/php-console": "Allow sending log messages to Google Chrome",
                 "raven/raven": "Allow sending log messages to a Sentry server",
                 "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
-                "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
             },
             "type": "library",
             "extra": {
@@ -593,7 +647,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2016-03-13 16:08:35"
+            "time": "2016-04-12 18:29:35"
         },
         {
             "name": "mtdowling/cron-expression",
@@ -950,16 +1004,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.0.3",
+            "version": "v3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "2ed5e2706ce92313d120b8fe50d1063bcfd12e04"
+                "reference": "6b1175135bc2a74c08a28d89761272de8beed8cd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/2ed5e2706ce92313d120b8fe50d1063bcfd12e04",
-                "reference": "2ed5e2706ce92313d120b8fe50d1063bcfd12e04",
+                "url": "https://api.github.com/repos/symfony/console/zipball/6b1175135bc2a74c08a28d89761272de8beed8cd",
+                "reference": "6b1175135bc2a74c08a28d89761272de8beed8cd",
                 "shasum": ""
             },
             "require": {
@@ -1006,20 +1060,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-02-28 16:24:34"
+            "time": "2016-03-16 17:00:50"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.0.3",
+            "version": "v3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "29606049ced1ec715475f88d1bbe587252a3476e"
+                "reference": "a06d10888a45afd97534506afb058ec38d9ba35b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/29606049ced1ec715475f88d1bbe587252a3476e",
-                "reference": "29606049ced1ec715475f88d1bbe587252a3476e",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/a06d10888a45afd97534506afb058ec38d9ba35b",
+                "reference": "a06d10888a45afd97534506afb058ec38d9ba35b",
                 "shasum": ""
             },
             "require": {
@@ -1063,20 +1117,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2016-01-27 05:14:46"
+            "time": "2016-03-30 10:41:14"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.0.3",
+            "version": "v3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "4dd5df31a28c0f82b41cb1e1599b74b5dcdbdafa"
+                "reference": "9002dcf018d884d294b1ef20a6f968efc1128f39"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/4dd5df31a28c0f82b41cb1e1599b74b5dcdbdafa",
-                "reference": "4dd5df31a28c0f82b41cb1e1599b74b5dcdbdafa",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/9002dcf018d884d294b1ef20a6f968efc1128f39",
+                "reference": "9002dcf018d884d294b1ef20a6f968efc1128f39",
                 "shasum": ""
             },
             "require": {
@@ -1123,20 +1177,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2016-01-27 05:14:46"
+            "time": "2016-03-10 10:34:12"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.0.3",
+            "version": "v3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "623bda0abd9aa29e529c8e9c08b3b84171914723"
+                "reference": "c54e407b35bc098916704e9fd090da21da4c4f52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/623bda0abd9aa29e529c8e9c08b3b84171914723",
-                "reference": "623bda0abd9aa29e529c8e9c08b3b84171914723",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/c54e407b35bc098916704e9fd090da21da4c4f52",
+                "reference": "c54e407b35bc098916704e9fd090da21da4c4f52",
                 "shasum": ""
             },
             "require": {
@@ -1172,24 +1226,25 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2016-01-27 05:14:46"
+            "time": "2016-03-10 11:13:05"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v3.0.3",
+            "version": "v3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "52065702c71743c05d415a8facfcad6d4257e8d7"
+                "reference": "99f38445a874e7becb8afc4b4a79ee181cf6ec3f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/52065702c71743c05d415a8facfcad6d4257e8d7",
-                "reference": "52065702c71743c05d415a8facfcad6d4257e8d7",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/99f38445a874e7becb8afc4b4a79ee181cf6ec3f",
+                "reference": "99f38445a874e7becb8afc4b4a79ee181cf6ec3f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": ">=5.5.9",
+                "symfony/polyfill-mbstring": "~1.1"
             },
             "require-dev": {
                 "symfony/expression-language": "~2.8|~3.0"
@@ -1224,20 +1279,20 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-02-28 16:24:34"
+            "time": "2016-03-27 14:50:32"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v3.0.3",
+            "version": "v3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "59c0a1972e9aad87b7a56bbe1ccee26b7535a0db"
+                "reference": "579f828489659d7b3430f4bd9b67b4618b387dea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/59c0a1972e9aad87b7a56bbe1ccee26b7535a0db",
-                "reference": "59c0a1972e9aad87b7a56bbe1ccee26b7535a0db",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/579f828489659d7b3430f4bd9b67b4618b387dea",
+                "reference": "579f828489659d7b3430f4bd9b67b4618b387dea",
                 "shasum": ""
             },
             "require": {
@@ -1306,7 +1361,7 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2016-02-28 21:33:13"
+            "time": "2016-03-25 01:41:20"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1477,16 +1532,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v3.0.3",
+            "version": "v3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "dfecef47506179db2501430e732adbf3793099c8"
+                "reference": "e6f1f98bbd355d209a992bfff45e7edfbd4a0776"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/dfecef47506179db2501430e732adbf3793099c8",
-                "reference": "dfecef47506179db2501430e732adbf3793099c8",
+                "url": "https://api.github.com/repos/symfony/process/zipball/e6f1f98bbd355d209a992bfff45e7edfbd4a0776",
+                "reference": "e6f1f98bbd355d209a992bfff45e7edfbd4a0776",
                 "shasum": ""
             },
             "require": {
@@ -1522,20 +1577,20 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2016-02-02 13:44:19"
+            "time": "2016-03-30 10:41:14"
         },
         {
             "name": "symfony/routing",
-            "version": "v3.0.3",
+            "version": "v3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "fa1e9a8173cf0077dd995205da453eacd758fdf6"
+                "reference": "d061b609f2d0769494c381ec92f5c5cc5e4a20aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/fa1e9a8173cf0077dd995205da453eacd758fdf6",
-                "reference": "fa1e9a8173cf0077dd995205da453eacd758fdf6",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/d061b609f2d0769494c381ec92f5c5cc5e4a20aa",
+                "reference": "d061b609f2d0769494c381ec92f5c5cc5e4a20aa",
                 "shasum": ""
             },
             "require": {
@@ -1597,20 +1652,20 @@
                 "uri",
                 "url"
             ],
-            "time": "2016-02-04 13:53:13"
+            "time": "2016-03-23 13:23:25"
         },
         {
             "name": "symfony/translation",
-            "version": "v3.0.3",
+            "version": "v3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "2de0b6f7ebe43cffd8a06996ebec6aab79ea9e91"
+                "reference": "f7a07af51ea067745a521dab1e3152044a2fb1f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/2de0b6f7ebe43cffd8a06996ebec6aab79ea9e91",
-                "reference": "2de0b6f7ebe43cffd8a06996ebec6aab79ea9e91",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/f7a07af51ea067745a521dab1e3152044a2fb1f2",
+                "reference": "f7a07af51ea067745a521dab1e3152044a2fb1f2",
                 "shasum": ""
             },
             "require": {
@@ -1661,20 +1716,20 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-02-02 13:44:19"
+            "time": "2016-03-25 01:41:20"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v3.0.3",
+            "version": "v3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "9a6a883c48acb215d4825ce9de61dccf93d62074"
+                "reference": "3841ed86527d18ee2c35fe4afb1b2fc60f8fae79"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/9a6a883c48acb215d4825ce9de61dccf93d62074",
-                "reference": "9a6a883c48acb215d4825ce9de61dccf93d62074",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/3841ed86527d18ee2c35fe4afb1b2fc60f8fae79",
+                "reference": "3841ed86527d18ee2c35fe4afb1b2fc60f8fae79",
                 "shasum": ""
             },
             "require": {
@@ -1724,7 +1779,7 @@
                 "debug",
                 "dump"
             ],
-            "time": "2016-02-13 09:23:44"
+            "time": "2016-03-10 10:34:12"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -2847,16 +2902,16 @@
         },
         {
             "name": "symfony/css-selector",
-            "version": "v3.0.3",
+            "version": "v3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "6605602690578496091ac20ec7a5cbd160d4dff4"
+                "reference": "65e764f404685f2dc20c057e889b3ad04b2e2db0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/6605602690578496091ac20ec7a5cbd160d4dff4",
-                "reference": "6605602690578496091ac20ec7a5cbd160d4dff4",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/65e764f404685f2dc20c057e889b3ad04b2e2db0",
+                "reference": "65e764f404685f2dc20c057e889b3ad04b2e2db0",
                 "shasum": ""
             },
             "require": {
@@ -2896,20 +2951,20 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2016-01-27 05:14:46"
+            "time": "2016-03-04 07:55:57"
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v3.0.3",
+            "version": "v3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "981c8edb4538f88ba976ed44bdcaa683fce3d6c6"
+                "reference": "18a06d7a9af41718c20764a674a0ebba3bc40d1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/981c8edb4538f88ba976ed44bdcaa683fce3d6c6",
-                "reference": "981c8edb4538f88ba976ed44bdcaa683fce3d6c6",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/18a06d7a9af41718c20764a674a0ebba3bc40d1f",
+                "reference": "18a06d7a9af41718c20764a674a0ebba3bc40d1f",
                 "shasum": ""
             },
             "require": {
@@ -2952,20 +3007,20 @@
             ],
             "description": "Symfony DomCrawler Component",
             "homepage": "https://symfony.com",
-            "time": "2016-02-28 16:24:34"
+            "time": "2016-03-23 13:23:25"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.0.3",
+            "version": "v3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "b5ba64cd67ecd6887f63868fa781ca094bd1377c"
+                "reference": "0047c8366744a16de7516622c5b7355336afae96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/b5ba64cd67ecd6887f63868fa781ca094bd1377c",
-                "reference": "b5ba64cd67ecd6887f63868fa781ca094bd1377c",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/0047c8366744a16de7516622c5b7355336afae96",
+                "reference": "0047c8366744a16de7516622c5b7355336afae96",
                 "shasum": ""
             },
             "require": {
@@ -3001,7 +3056,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-02-23 15:16:06"
+            "time": "2016-03-04 07:55:57"
         }
     ],
     "aliases": [],

--- a/config/app.php
+++ b/config/app.php
@@ -156,6 +156,7 @@ return [
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
 
+        Collective\Html\HtmlServiceProvider::class,
     ],
 
     /*
@@ -202,6 +203,7 @@ return [
         'Validator' => Illuminate\Support\Facades\Validator::class,
         'View' => Illuminate\Support\Facades\View::class,
 
+        'Html' => Collective\Html\HtmlFacade::class,
     ],
 
 ];

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -632,3 +632,24 @@ Errors
 	font-size: 13px;
 	letter-spacing: .1px;
 }
+
+/*
+======================================
+Animations
+======================================
+*/
+
+/* Source: http://jsfiddle.net/nprather/WKSrV/3/ */
+@-webkit-keyframes yellow-fade {
+	0% {background: gold;}
+	100% {background: none;}
+}
+@keyframes yellow-fade {
+	0% {background: gold;}
+	100% {background: none;}
+}
+
+.highlight {
+	-webkit-animation: yellow-fade 2s ease-in 1;
+	animation: yellow-fade 2s ease-in 1;
+}

--- a/public/js/jsmain.js
+++ b/public/js/jsmain.js
@@ -2,3 +2,13 @@ function redirectmain()
 {
 	location.href = "projectmain.html";
 }
+
+function writeCharCount(name)
+{
+	var input = document.getElementById(name);
+	var element = document.getElementById(name + "-count");
+	element.style.color = (input.value.length < input.minLength ? "red" : "black");
+	element.style.fontSize = "14px";
+	// element.innerHTML = " characters remaining: " + input.value.length;
+	element.innerHTML = (input.value.length > 0) ? "" + input.value.length + "/" + input.maxLength : "";
+}

--- a/resources/views/layouts/main_layout.blade.php
+++ b/resources/views/layouts/main_layout.blade.php
@@ -59,7 +59,7 @@
                 <ul>
                     <li><a href="">Home</a></li><!--
 			        --><li><a href="/projectfinder">Explore</a></li><!--
-			        --><li><a href="/create">Start a project</a></li><!--
+			        --><li><a href="/project-create">Start a project</a></li><!--
 			        --><li><a href="/about">About us</a></li>
                 </ul>
             </nav>
@@ -78,7 +78,7 @@
                 <ul>
                     <li><a href="">Home</a></li><!--
 			        --><li><a href="/projectfinder">Explore</a></li><!--
-			        --><li><a href="/create">Start a project</a></li><!--
+			        --><li><a href="/project-create">Start a project</a></li><!--
 			        --><li><a href="/about">About us</a></li><!--
 			        --><li><a href="">Contact us</a></li>
                 </ul>

--- a/resources/views/pages/create.blade.php
+++ b/resources/views/pages/create.blade.php
@@ -3,6 +3,7 @@
 @section('head')
 
     <title>Create Project</title>
+    {{ Html::script('js/jsmain.js') }}
 
 @endsection
 
@@ -13,21 +14,47 @@
         {!! csrf_field() !!}
 
         <h5>Create Project</h5>
+
+        <!-- Thumbnail -->
         <div class="form-group">
             <label for="thumbnail">Thumbnail</label>
-            <input class="form-control" type="file" id="thumbnail" name="thumbnail">
+            <input class="form-control" type="file" id="thumbnail" name="thumbnail" value="{{old('thumbnail')}}">
+            @if ($errors->has('thumbnail'))
+                <span class="error-auth">{{ $errors->first('thumbnail') }}</span>
+            @endif
         </div>
+
+        <!-- Title -->
         <div class="form-group">
             <label for="title">Title</label>
-            <input class="form-control" type="text" id="title" name="title" placeholder="Your project's title">
+            <input class="form-control" type="text" id="title" name="title" placeholder="Your project's title" value="{{old('title')}}"
+                   minlength="{{ \App\Project::attributeLengths()['title']['min'] }}" maxlength="{{ \App\Project::attributeLengths()['title']['max'] }}" onkeyup="writeCharCount('title')">
+            <p id="title-count"></p>
+            @if ($errors->has('title'))
+                <span class="error-auth">{{ $errors->first('title') }}</span>
+            @endif
         </div>
+
+        <!-- Description -->
         <div class="form-group">
             <label for="description">Description</label>
-            <input class="form-control" type="text" id="description" name="description" placeholder="A short description" maxlength="100" size="88" height="2">
+            <input class="form-control" type="text" id="description" name="description" placeholder="A short description" value="{{old('description')}}" size="88" height="2"
+                   minlength="{{ \App\Project::attributeLengths()['description']['min'] }}" maxlength="{{ \App\Project::attributeLengths()['description']['max'] }}" onkeyup="writeCharCount('description')">
+            <p id="description-count"></p>
+            @if ($errors->has('description'))
+                <span class="error-auth">{{ $errors->first('description') }}</span>
+            @endif
         </div>
+
+        <!-- Project Body -->
         <div class="form-group">
             <label for="project-body">About The Project</label>
-            <textarea class="form-control" id="project-body" name="project-body" rows="15" placeholder="All the details of your project"></textarea>
+            <textarea class="form-control" id="project-body" name="project-body" rows="15" placeholder="All the details of your project"
+                      minlength="{{ \App\Project::attributeLengths()['project-body']['min'] }}" maxlength="{{ \App\Project::attributeLengths()['project-body']['max'] }}" onkeyup="writeCharCount('project-body')">{{old('project-body')}}</textarea>
+            <p id="project-body-count"></p>
+            @if ($errors->has('project-body'))
+                <span class="error-auth">{{ $errors->first('project-body') }}</span>
+            @endif
         </div>
         <button type="submit" id="submit" class="btn btn-primary">Submit</button>
         <a href="/projectfinder">

--- a/resources/views/pages/project-create.blade.php
+++ b/resources/views/pages/project-create.blade.php
@@ -10,7 +10,7 @@
 @section('mainBody')
 
 <main class="container primary-main row">
-    <form role="form" class="project-form" action="{{ url('/create') }}" method="post" enctype="multipart/form-data">
+    <form role="form" class="project-form" action="{{ url('/project-create') }}" method="post" enctype="multipart/form-data">
         {!! csrf_field() !!}
 
         <h5>Create Project</h5>

--- a/resources/views/pages/project.blade.php
+++ b/resources/views/pages/project.blade.php
@@ -21,7 +21,7 @@
             </div>
             @if (Auth::check() && Auth::user()->username == $project->author)
             <div class="project-page-elements">
-                <a href="/delete-project/{{ $project->id }}">
+                <a href="/project/{{ $project->id }}/delete">
                     <button type="button" id="delete">Delete</button>
                 </a>
             </div>

--- a/resources/views/pages/project.blade.php
+++ b/resources/views/pages/project.blade.php
@@ -21,7 +21,7 @@
             </div>
             @if (Auth::check() && Auth::user()->username == $project->author)
             <div class="project-page-elements">
-                <a href="/project/{{ $project->id }}/delete">
+                <a href="{{ $project->getSlug() }}/delete">
                     <button type="button" id="delete">Delete</button>
                 </a>
             </div>

--- a/resources/views/pages/project.blade.php
+++ b/resources/views/pages/project.blade.php
@@ -10,7 +10,7 @@
     <main class="container project-page">
         <div class="row">
             <div class="col-1-2">
-                <img src="/images/projects/product{{ $project->id }}.jpg" alt="Project Image" border="1px">
+                <img src="{{ $project->getImagePath() }}" alt="Project Image" border="1px">
             </div>
             <div class="col-1-2">
                 <h5>{{ $project->title }} by {{ $project->author  }}</h5>

--- a/resources/views/pages/projectfinder.blade.php
+++ b/resources/views/pages/projectfinder.blade.php
@@ -13,6 +13,12 @@
 <main class="primary-main row project-main">
 
     <section class="container">
+        <section class ="grid">
+        @if(Session::has('delete-success'))
+            <div class="alert alert-info highlight col-sm-1" >{{ Session::get('delete-success') }}</div>
+        @endif
+        </section>
+
         <ul class="project-search">
             <li><input class="search-textbox" type="text" name="searchName" placeholder="Project title..."></li><!--
 			--><li><input class="btn btn-search" type="button" name="search" value="Search"></li>

--- a/resources/views/pages/projectfinder.blade.php
+++ b/resources/views/pages/projectfinder.blade.php
@@ -37,7 +37,7 @@
     <section class="grid">
         @foreach($projects as $project)
             <div class="col-1-3 project-teaser">
-                <a href="project/{{ $project->id }}">
+                <a href="{{ $project->getSlug() }}">
                     <img src="/images/projects/product{{ $project->id }}.jpg" alt="Project Image">
                     <h4>{{ $project->title }}</h4>
                     <p>{{ $project->description }}</p>

--- a/resources/views/pages/projectfinder.blade.php
+++ b/resources/views/pages/projectfinder.blade.php
@@ -38,7 +38,7 @@
         @foreach($projects as $project)
             <div class="col-1-3 project-teaser">
                 <a href="{{ $project->getSlug() }}">
-                    <img src="/images/projects/product{{ $project->id }}.jpg" alt="Project Image">
+                    <img src="{{ $project->getImagePath() }}" alt="Project Image">
                     <h4>{{ $project->title }}</h4>
                     <p>{{ $project->description }}</p>
                     <p class="team-count">Total members: 30</p>

--- a/tests/forms/CreateProjectTest.php
+++ b/tests/forms/CreateProjectTest.php
@@ -13,13 +13,12 @@ class CreateProjectTest extends TestCase
      */
     public function testCreateProject()
     {
-        $this->setup();
-        $this->visit('/create')
+        $this->visit('/project-create')
             ->seePageIs('/login');
 
         $user = factory(App\User::class)->make(['username' => 'test_user']);
 
-        $base = base_path() . '/public/images/';
+        $base = base_path() . '/public/images';
         $testImage = $base . '/test-project-image.jpg';
 
         /* !! Validation is needed on project create form first
@@ -44,15 +43,16 @@ class CreateProjectTest extends TestCase
         // Create and retrieve good project
         $this->tryCreateProject($user,
             'Test Project',
-            'Create test!',
-            'This is not the body you are looking for.',
+            'Create test please work',
+            'This is not the body you are looking for. This is not the body you are looking for. This is not the body you are looking for. This is not the body you are looking for. This is not the body you are looking for. ',
             $testImage
         );
         $entry = App\Project::where('title', '=', 'Test Project')->first();
-        $this->seePageIs('/project/' . $entry->id);
+        $this->assertTrue($entry != null);
+        $this->seePageIs($entry->getSlug());
 
         // Check if image exists
-        $imagePath = $base . 'projects/product' . $entry->id . '.jpg';
+        $imagePath = $base . '/projects/product' . $entry->id . '.jpg';
         $this->assertTrue(file_exists($imagePath));
 
         // Delete project using delete button
@@ -68,7 +68,7 @@ class CreateProjectTest extends TestCase
     private function tryCreateProject($user, $title, $description, $body, $image)
     {
         return $this->actingAs($user)
-            ->visit('/create')
+            ->visit('/project-create')
             ->type($title, 'title')
             ->type($description, 'description')
             ->type($body, 'project-body')


### PR DESCRIPTION
Resolves #58. @uidaho/lambda, please review!
- Update project route to use names instead of ids, so its now `/project/my-project-title`.
- Update project route to follow better formatting
  - the only lame duck is create project page: `/project-create`. Couldn't do `/project/create` as the resolver would try to find a project named create instead of take you to the create page. 
- Enforce alpha numeric naming for the project names. (#73)
- Enrich the `Project` model to offer lots of helper functions for use throughout project.
