### PR TITLE
allow spaces in titles and deprecate slug

### DIFF
--- a/app/Http/Controllers/EditorController.php
+++ b/app/Http/Controllers/EditorController.php
@@ -35,12 +35,13 @@ class EditorController extends Controller
     {
         $userid = Auth::user()->id;
         $username = Auth::user()->username;
+        $project = Project::where('title', $projectname)->firstOrFail();
 
-        $file = File::where('projectname', Project::getTitleFromSlug($projectname))
+        $file = File::where('project_id', $project->id)
                     ->where('filename', $filename)
                     ->firstOrFail();
 
-        return view('editor.edit', ['file' => $file, 'userid' => $userid, 'username' => $username]);
+        return view('editor.edit', ['file' => $file, 'userid' => $userid, 'username' => $username, 'project' => $project]);
     }
 
     /**
@@ -52,7 +53,7 @@ class EditorController extends Controller
     public function listFiles($projectname)
     {
         $userid = Auth::user()->id;
-        $project = Project::fromSlug($projectname)->get()->first();
+        $project = Project::where('title', $projectname)->firstOrFail();
         $files = File::forProject($project)->get();
 
         if (empty($files[0])) {

--- a/app/Http/Controllers/ProjectCommentsController.php
+++ b/app/Http/Controllers/ProjectCommentsController.php
@@ -63,7 +63,7 @@ class ProjectCommentsController extends Controller
         $this->authorize('userIsOwner', $projectComment);
 
         $projectComment->update($request->all());
-        $projectPath = 'project/' . str_replace(' ', '-', $projectComment->project->title);
+        $projectPath = 'project/' . $projectComment->project->title;
 
         return redirect($projectPath);
     }

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -34,8 +34,10 @@ class ProjectController extends Controller
      * @return The project page view
      * @internal param Project $id id for lookup
      */
-    public function view(Project $project)
+    public function view($projectname)
     {
+        $project = Project::where('title', $projectname)->firstOrFail();
+        
         return view('project.view', ['project' => $project]);
     }
 
@@ -70,7 +72,7 @@ class ProjectController extends Controller
         $thumbnail = $request->file('thumbnail');
         $thumbnail->move(base_path() . '/public/images/projects',  'product' . $newEntry->id . '.jpg');
 
-        return redirect($newEntry->getSlug());
+        return redirect('/project/'.$newEntry->title);
     }
 
     /**

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -40,8 +40,8 @@ Route::post('project/create', 'ProjectController@create');
 Route::get('project/delete/{project}', 'ProjectController@delete');
 Route::get('project', 'ProjectController@listProjects');
 Route::get('projects', 'ProjectController@listProjects');
-Route::get('project/view/{project}', 'ProjectController@view');
-Route::get('project/{project}', 'ProjectController@view'); // overloads go last.
+Route::get('project/view/{projectname}', 'ProjectController@view');
+Route::get('project/{projectname}', 'ProjectController@view'); // overloads go last.
 Route::get('project/follow/{project}', 'ProjectController@addFollower');
 Route::get('project/unfollow/{project}', 'ProjectController@removeFollower');
 

--- a/app/Project.php
+++ b/app/Project.php
@@ -20,7 +20,7 @@ class Project extends Model
      */
     public function getSlug()
     {
-        return '/project/' . $this->getSlugFriendlyTitle();
+        return '/project/' . $this->title;
     }
 
     /**
@@ -42,7 +42,8 @@ class Project extends Model
      */
     public static function getTitleFromSlug($slug)
     {
-        return str_replace('-', ' ', $slug);
+        //return str_replace('-', ' ', $slug);
+        return $slug;
     }
 
 

--- a/app/Project.php
+++ b/app/Project.php
@@ -30,7 +30,8 @@ class Project extends Model
      */
     public function getSlugFriendlyTitle()
     {
-        return str_replace(' ', '-', $this->title);
+        //return str_replace(' ', '-', $this->title);  //deprecated
+        return $this->title;
     }
 
     /**
@@ -54,7 +55,7 @@ class Project extends Model
      */
     public static function fromSlug($slug)
     {
-        return (new static)->where('title', str_replace('-', ' ', $slug));
+        return (new static)->where('title', $slug);
     }
 
     /**

--- a/resources/views/editor/edit.blade.php
+++ b/resources/views/editor/edit.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.main_layout')
 
 @section('head')
-    <title>{{$file->projectname}}/{{$file->filename}} | The Squire Project</title>
+    <title>{{$project->title}}/{{$file->filename}} | The Squire Project</title>
 
     <script src="https://cdn.firebase.com/js/client/2.3.2/firebase.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.10.0/codemirror.css" />

--- a/tests/forms/CreateProjectTest.php
+++ b/tests/forms/CreateProjectTest.php
@@ -48,7 +48,7 @@ class CreateProjectTest extends TestCase  // disable bad failing test, confirmed
             'Create test please work',
             'This is not the body you are looking for. This is not the body you are looking for. This is not the body you are looking for. This is not the body you are looking for. This is not the body you are looking for. ',
             $this->testImage
-        )->seePageIs('/project/Test-Project');
+        )->seePageIs('/project/Test Project');
         $entry = App\Project::where('title', '=', 'Test Project')->first();
         $this->assertTrue($entry != null);
         $this->seePageIs($entry->getSlug());


### PR DESCRIPTION
Since we want to support spaces in project titles, this is the easiest way to do it. For the sake of simplicity we'll just have to deal with %20's in the URL.
